### PR TITLE
Fixed no body on error crash

### DIFF
--- a/lib/resources/client.js
+++ b/lib/resources/client.js
@@ -38,6 +38,7 @@ Client.prototype.request = function(options, callback) {
       code: code
     }))
 
+    body = body || {message: 'No Body'};
     // assign error message if 400
     if (!err && code >= 400) {
       err = new Error(body.message)


### PR DESCRIPTION
I found that sometimes on some error code >= 400, no body wsas present causing my app to crash. This passes the current tests; however, I did not write a regression test to catch the case in question. I can do so if you like. Let me know. Best, Aaron
