### PR TITLE
auth needs to be in the deeper options.options to be included in the queryString

### DIFF
--- a/lib/resources/client.js
+++ b/lib/resources/client.js
@@ -25,7 +25,7 @@ Client.prototype.request = function(options, callback) {
   options = options || {};
   
   if (this.auth) {
-    options.auth = this.auth;
+    options.options.auth = this.auth;
   }
 
   var requestUrl = _requestUrl(network, version, options)


### PR DESCRIPTION
I didn't actually run the code with my change to put auth in the options hash, otherwise I would have caught this before. Do you mind bumping the release again @sidazhang?

Sorry for the borked PR.
